### PR TITLE
Rename to be gh-scoped-creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pip install gh-scoped-creds
 ## Client configuration
 
 1. `gh-scoped-creds` uses `git-credentials-store` to provide appropriate authentication,
-    by writing to a `/tmp/github-scoped-credentials` file. This makes sure we don't override
+    by writing to a `/tmp/gh-scoped-creds` file. This makes sure we don't override
 	the default `~/.git-credentials` file someone might be using. `git` will have to be configured to use
 	the new file.
 
@@ -85,13 +85,13 @@ pip install gh-scoped-creds
 
 	```ini
 	[credential]
-        helper = store --file=/tmp/github-scoped-credentials
+        helper = store --file=/tmp/gh-scoped-creds
 	```
 
 	Or you can run the following command (this puts it in `~/.gitconfig`)
 
 	```
-	git config --global credential.helper "store --file=/tmp/github-scoped-credentials"
+	git config --global credential.helper "store --file=/tmp/gh-scoped-creds"
 	```
 
    **Note for non-container uses**: If your users are on a HPC system or similar,

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pip install gh-scoped-creds
 
 2. `gh-scoped-creds` will need to know the "Client ID" of the created GitHub app to
     perform authentication. This can be either set with the environment variable
-	`GITHUB_APP_CLIENT_ID`, or be passed in as a commandline parameter `--client-id` to
+	`GH_SCOPED_CREDS_CLIENT_ID`, or be passed in as a commandline parameter `--client-id` to
 	the `gh-scoped-creds` script when users use it to authenticate.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# github-app-user-auth
+# gh-scoped-creds
 
-Provide fine-grained push access to GitHub from a JupyterHub.
+Provide finely scoped push access to GitHub from a JupyterHub or
+HPC system.
 
 ## Goals
 
@@ -24,19 +25,21 @@ These goals are accomplished by:
    and GitHub organization admins can then provide fine grained, repo
    level access to this GitHub app - Users can only push to repos that have the
    app installed.
-2. A commandline tool (`github-app-user-auth`) that lets specific users
+2. A commandline tool (`gh-scoped-creds`) that lets specific users
    authorize push access to the selected repositories temporarily - a token
    that expires after 8 hours.
+3. An IPython Magic (`%ghscopedcreds`) that provides a convenient wrapper to call
+   `gh-scoped-creds` from inside a Jupyter Notebook.
 
 In the future, an optional web app might also be provided to aid in
 authentication.
 
 ## Installation
 
-You can install `github-app-user-auth` from PyPI.
+You can install `gh-scoped-creds` from PyPI.
 
 ```bash
-pip install github-app-user-auth
+pip install gh-scoped-creds
 ```
 
 ## GitHub App configuration
@@ -72,8 +75,8 @@ pip install github-app-user-auth
 
 ## Client configuration
 
-1. `github-app-user-auth` uses `git-credentials-store` to provide appropriate authentication,
-    by writing to a `/tmp/github-app-git-credentials` file. This makes sure we don't override
+1. `gh-scoped-creds` uses `git-credentials-store` to provide appropriate authentication,
+    by writing to a `/tmp/github-scoped-credentials` file. This makes sure we don't override
 	the default `~/.git-credentials` file someone might be using. `git` will have to be configured to use
 	the new file.
 
@@ -82,25 +85,25 @@ pip install github-app-user-auth
 
 	```ini
 	[credential]
-        helper = store --file=/tmp/github-app-git-credentials
+        helper = store --file=/tmp/github-scoped-credentials
 	```
 
 	Or you can run the following command (this puts it in `~/.gitconfig`)
 
 	```
-	git config --global credential.helper "store --file=/tmp/github-app-git-credentials"
+	git config --global credential.helper "store --file=/tmp/github-scoped-credentials"
 	```
 
    **Note for non-container uses**: If your users are on a HPC system or similar,
    where `/tmp` is not isolated for each user, you must set the file path to be
-   under `$HOME`. The `github-app-user-auth` commandline tool used by end users
+   under `$HOME`. The `gh-scoped-creds` commandline tool used by end users
    (documented below) accepts a `--git-credentials-path` that can be explicitly
    set. The same path must be used in `gitconfig` here as well.
 
-2. `github-app-user-auth` will need to know the "Client ID" of the created GitHub app to
+2. `gh-scoped-creds` will need to know the "Client ID" of the created GitHub app to
     perform authentication. This can be either set with the environment variable
 	`GITHUB_APP_CLIENT_ID`, or be passed in as a commandline parameter `--client-id` to
-	the `github-app-user-auth` script when users use it to authenticate.
+	the `gh-scoped-creds` script when users use it to authenticate.
 
 ## Usage
 
@@ -119,15 +122,15 @@ not be too cumborsome.
 
 ### Authenticate to GitHub
 
-The hosted service must have `github-app-user-auth` installed.
+The hosted service must have `gh-scoped-creds` installed.
 
-1. Open a terminal, and type `github-app-user-auth`. If you're in a Python based
+1. Open a terminal, and type `gh-scoped-creds`. If you're in a Python based
    Jupyter Notebook, you can also do:
 
    ```python
-   import github_app_user_auth
+   import gh_scoped_creds
 
-   %ghauth
+   %ghscopedauth
    ```
 
    This will offer to open the page in a new window for you, and conveniently

--- a/gh_scoped_creds/__init__.py
+++ b/gh_scoped_creds/__init__.py
@@ -77,7 +77,7 @@ def main(args=None, in_jupyter=False):
     )
     argparser.add_argument(
         "--git-credentials-path",
-        default="/tmp/github-scoped-credentials",
+        default="/tmp/gh-scoped-creds",
         help="""
         Path to write the git-credentials file to. Current contents will be overwritten!
         """.strip(),

--- a/gh_scoped_creds/__init__.py
+++ b/gh_scoped_creds/__init__.py
@@ -37,13 +37,6 @@ def do_authenticate_device_flow(client_id, in_jupyter=False):
         display(Javascript(f'navigator.clipboard.writeText("{code}");'))
         print(f"The code {code} has been copied to your clipboard.")
         print(f"You have 15 minutes to go to {url} and paste it there.\n")
-        ans = input(
-            "Hit ENTER to open that page in a new tab (type anything to cancel)>"
-        )
-        if ans:
-            print("Automatic opening canceled!")
-        else:
-            display(Javascript(f'window.open("{url}", "_blank");'))
     else:
         print(f"You have 15 minutes to go to {url} and enter the code: {code}")
 

--- a/gh_scoped_creds/__init__.py
+++ b/gh_scoped_creds/__init__.py
@@ -70,14 +70,14 @@ def main(args=None, in_jupyter=False):
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
         "--client-id",
-        default=os.environ.get("GITHUB_APP_CLIENT_ID"),
+        default=os.environ.get("GH_SCOPED_CREDS_CLIENT_ID"),
         help="""
         Client ID of the GitHub app to authenticate with as the user
         """.strip(),
     )
     argparser.add_argument(
         "--git-credentials-path",
-        default="/tmp/github-app-git-credentials",
+        default="/tmp/github-scoped-credentials",
         help="""
         Path to write the git-credentials file to. Current contents will be overwritten!
         """.strip(),
@@ -87,7 +87,7 @@ def main(args=None, in_jupyter=False):
 
     if not args.client_id:
         print(
-            "--client-id must be specified or GITHUB_APP_CLIENT_ID environment variable must be set",
+            "--client-id must be specified or GH_SCOPED_CREDS_CLIENT_ID environment variable must be set",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -129,7 +129,7 @@ try:
     if in_jupyter:
 
         @register_line_magic
-        def ghauth(line):
+        def ghscopedcreds(line):
             """
             IPython magic for authenticating to GitHub
             """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="gh-scoped-creds",
-    version="2.1",
+    version="2.2",
     url="https://github.com/yuvipanda/gh-scoped-creds",
     license="3-clause BSD",
     author="Yuvi Panda",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="gh-scoped-creds",
-    version="2.0",
+    version="2.1",
     url="https://github.com/yuvipanda/gh-scoped-creds",
     license="3-clause BSD",
     author="Yuvi Panda",

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import find_packages, setup
 
 setup(
-    name="github-app-user-auth",
-    version="1.1",
-    url="https://github.com/yuvipanda/github-app-user-auth",
+    name="gh-scoped-creds",
+    version="2.0",
+    url="https://github.com/yuvipanda/gh-scoped-creds",
     license="3-clause BSD",
     author="Yuvi Panda",
     author_email="yuvipanda@gmail.com",
-    description="Collection of git-credential helpers",
+    description="Temporary, well scoped credentials for pushing to GitHub",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     packages=find_packages(),
@@ -15,7 +15,9 @@ setup(
     install_requires=["requests"],
     entry_points={
         "console_scripts": [
-            "github-app-user-auth = github_app_user_auth:main",
+            # Backwards compatible script providing former (pre 2.0) name
+            "github-app-user-auth = gh_scoped_creds:main",
+            "gh-scoped-creds = gh_scoped_creds:main",
         ],
     },
 )


### PR DESCRIPTION
- Better name for what it actually does
- Prefix env var we use to pick up client id
- Rename the IPython Magic too

Ref https://github.com/yuvipanda/gh-scoped-creds/issues/2