### PR TITLE
Automatically tell git where to look for github creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,35 +75,23 @@ pip install gh-scoped-creds
 
 ## Client configuration
 
-1. `gh-scoped-creds` uses `git-credentials-store` to provide appropriate authentication,
-    by writing to a `/tmp/gh-scoped-creds` file. This makes sure we don't override
-	the default `~/.git-credentials` file someone might be using. `git` will have to be configured to use
-	the new file.
+1. `gh-scoped-creds` will need to know the "Client ID" of the created GitHub app to
+    perform authentication. This can be either set with the environment variable
+	`GH_SCOPED_CREDS_CLIENT_ID`, or be passed in as a commandline parameter `--client-id` to
+	the `gh-scoped-creds` script when users use it to authenticate.
 
-	You can put the following snippet in `/etc/gitconfig` (for containers) or in
-	`~/.gitconfig`:
-
-	```ini
-	[credential]
-        helper = store --file=/tmp/gh-scoped-creds
-	```
-
-	Or you can run the following command (this puts it in `~/.gitconfig`)
-
-	```
-	git config --global credential.helper "store --file=/tmp/gh-scoped-creds"
-	```
+1. `gh-scoped-creds` uses [`git-credentials-store`](https://git-scm.com/docs/git-credential-store)
+   to provide appropriate authentication, by writing to a `/tmp/gh-scoped-creds`
+   file. This makes sure we don't override the default `~/.git-credentials` file
+   someone might be using. `git` will be automatically configured (via an entry
+   in `~/.gitconfig`) to use this file for github.com credentials.  the new
+   file.
 
    **Note for non-container uses**: If your users are on a HPC system or similar,
    where `/tmp` is not isolated for each user, you must set the file path to be
    under `$HOME`. The `gh-scoped-creds` commandline tool used by end users
    (documented below) accepts a `--git-credentials-path` that can be explicitly
-   set. The same path must be used in `gitconfig` here as well.
-
-2. `gh-scoped-creds` will need to know the "Client ID" of the created GitHub app to
-    perform authentication. This can be either set with the environment variable
-	`GH_SCOPED_CREDS_CLIENT_ID`, or be passed in as a commandline parameter `--client-id` to
-	the `gh-scoped-creds` script when users use it to authenticate.
+   set.
 
 ## Usage
 

--- a/gh_scoped_creds/__init__.py
+++ b/gh_scoped_creds/__init__.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 import time
+import subprocess
 
 import requests
 
@@ -92,6 +93,17 @@ def main(args=None, in_jupyter=False):
         os.open(args.git_credentials_path, os.O_WRONLY | os.O_CREAT, 0o600), "w"
     ) as f:
         f.write(f"https://x-access-token:{access_token}@github.com\n")
+
+    # Tell git to use our new creds when talking to github
+    subprocess.check_call(
+        [
+            "git",
+            "config",
+            "--global", # Modifies ~/.gitconfig
+            "credential.https://github.com.helper",
+            f"store --file={args.git_credentials_path}",
+        ]
+    )
 
     expires_in_hours = expires_in / 60 / 60
     success = (

--- a/gh_scoped_creds/__init__.py
+++ b/gh_scoped_creds/__init__.py
@@ -1,8 +1,8 @@
 import argparse
 import os
+import subprocess
 import sys
 import time
-import subprocess
 
 import requests
 
@@ -99,7 +99,7 @@ def main(args=None, in_jupyter=False):
         [
             "git",
             "config",
-            "--global", # Modifies ~/.gitconfig
+            "--global",  # Modifies ~/.gitconfig
             "credential.https://github.com.helper",
             f"store --file={args.git_credentials_path}",
         ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="gh-scoped-creds",
-    version="2.2",
+    version="3.0",
     url="https://github.com/yuvipanda/gh-scoped-creds",
     license="3-clause BSD",
     author="Yuvi Panda",


### PR DESCRIPTION
Removes a fiddly client-side config! This was particularly
problematic when git was installed via conda, as it does not
read the systemwide /etc/gitconfig file
(https://github.com/conda-forge/git-feedstock/issues/113)

Ref #2