### PR TITLE
Remove hard-coded credentials file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,6 @@ pip install gh-scoped-creds
    the `GH_SCOPED_CREDS_APP_URL` environment variable to inform users where to go
    to manage this access - `gh-scoped-creds` will print this out after authentication.
 
-3. `gh-scoped-creds` uses [`git-credentials-store`](https://git-scm.com/docs/git-credential-store)
-   to provide appropriate authentication, by writing to a `/tmp/gh-scoped-creds`
-   file. This makes sure we don't override the default `~/.git-credentials` file
-   someone might be using. `git` will be automatically configured (via an entry
-   in `~/.gitconfig`) to use this file for github.com credentials.
-
-   **Note for non-container uses**: If your users are on a HPC system or similar,
-   where `/tmp` is not isolated for each user, you must set the file path to be
-   under `$HOME`. The `gh-scoped-creds` commandline tool used by end users
-   (documented below) accepts a `--git-credentials-path` that can be explicitly
-   set.
-
 ## Usage
 
 ### Grant access to the GitHub app

--- a/gh_scoped_creds/__init__.py
+++ b/gh_scoped_creds/__init__.py
@@ -1,8 +1,8 @@
 import argparse
 import os
 import subprocess
-import tempfile
 import sys
+import tempfile
 import time
 
 import requests
@@ -90,7 +90,7 @@ def main(args=None, in_jupyter=False):
     access_token, expires_in = do_authenticate_device_flow(args.client_id, in_jupyter)
 
     # Create a secure temporary file and write the creds to it
-    with tempfile.NamedTemporaryFile(delete=False, mode='w+') as f:
+    with tempfile.NamedTemporaryFile(delete=False, mode="w+") as f:
         f.write(f"https://x-access-token:{access_token}@github.com\n")
         f.flush()
 

--- a/gh_scoped_creds/__init__.py
+++ b/gh_scoped_creds/__init__.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import subprocess
+import tempfile
 import sys
 import time
 
@@ -76,13 +77,6 @@ def main(args=None, in_jupyter=False):
         URL where users can install & grant repo access to the app
         """.strip()
     )
-    argparser.add_argument(
-        "--git-credentials-path",
-        default="/tmp/gh-scoped-creds",
-        help="""
-        Path to write the git-credentials file to. Current contents will be overwritten!
-        """.strip(),
-    )
 
     args = argparser.parse_args(args)
 
@@ -95,22 +89,21 @@ def main(args=None, in_jupyter=False):
 
     access_token, expires_in = do_authenticate_device_flow(args.client_id, in_jupyter)
 
-    # Create the file with appropriate permissions (0600) so other users can't read it
-    with open(
-        os.open(args.git_credentials_path, os.O_WRONLY | os.O_CREAT, 0o600), "w"
-    ) as f:
+    # Create a secure temporary file and write the creds to it
+    with tempfile.NamedTemporaryFile(delete=False, mode='w+') as f:
         f.write(f"https://x-access-token:{access_token}@github.com\n")
+        f.flush()
 
-    # Tell git to use our new creds when talking to github
-    subprocess.check_call(
-        [
-            "git",
-            "config",
-            "--global",  # Modifies ~/.gitconfig
-            "credential.https://github.com.helper",
-            f"store --file={args.git_credentials_path}",
-        ]
-    )
+        # Tell git to use our new creds when talking to github
+        subprocess.check_call(
+            [
+                "git",
+                "config",
+                "--global",  # Modifies ~/.gitconfig
+                "credential.https://github.com.helper",
+                f"store --file={f.name}",
+            ]
+        )
 
     expires_in_hours = expires_in / 60 / 60
     success = f"Success! Authentication will expire in {expires_in_hours:0.1f} hours.\n"


### PR DESCRIPTION
We needed admins to setup .gitconfig to point to the generated
credentials file earlier, and so we used a well known location.
Now that we set git config automatically, that is unnecessary.

This makes it secure to use on HPC systems